### PR TITLE
src/simdocmgr.py: Use Pythonic try/except instead of isinstance().

### DIFF
--- a/src/simdocmgr.py
+++ b/src/simdocmgr.py
@@ -255,9 +255,9 @@ class ScannerSessionForm(npyscreen.FormBaseNew):
         locDateFldObj = self.fldEffDt.value
 
         #locDateObj = datetime.strptime(locDateFldObj, '%d %B, %Y').date()
-        if isinstance(locDateFldObj, datetime):
+        try:
             locEffDate = locDateFldObj.strftime('%Y-%m-%d')
-        else:
+        except AttributeError:
             locEffDate = ''
 
         locDocName = locDocFn


### PR DESCRIPTION
In many other languages, it is important to check if something is
allowed before doing it. This technique is called "Look before
you leap" or "LBYL". In Python you can avoid this tedious
pre-checking because error recovery is so easy. In Python, just
go ahead and try something. If it blows up, do something else.
This technique is called "Easier to ask forgiveness than
permission" or "EAFP". This is one of Python's super-powers.

Also, it is Pythonic to avoid using isinstance(). Notice that the
new code only cares if the object supports the strftime() method
without caring if it is subclassed from datetime.datetime.
This is called [duck typing](https://en.wikipedia.org/wiki/Duck_typing).

Raymond Hetting has covered this stuff in his videos.
I don't remember which ones. They are great to watch.
Below are two.

    [Transforming Code into Beautiful, Idiomatic Python](http://pyvideo.org/pycon-us-2013/transforming-code-into-beautiful-idiomatic-pytho.html)
    [Keynote - What Makes Python Awesome](http://pyvideo.org/pycon-us-2013/keynote-3.html)